### PR TITLE
Update dependencies & plugins for Java 17 & SpringBoot 3.0 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>com.mercateo.rest</groupId>
     <artifactId>rest-schemagen-spring</artifactId>
-    <version>0.3.1-SNAPSHOT</version>
+    <version>0.4.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>rest-schemagen-spring</name>
@@ -64,21 +64,26 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <java.version>1.8</java.version>
-        <spring.version>5.0.20.RELEASE</spring.version>
+        <java.version>17</java.version>
+        <spring.version>6.0.10</spring.version>
     </properties>
 
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.1.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.3</version>
+                <version>3.0.1</version>
             </plugin>
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.8</version>
+                <version>1.6.13</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>
@@ -89,11 +94,10 @@
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
+                <version>3.11.0</version>
                 <configuration>
                     <compilerVersion>1.8</compilerVersion>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <release>17</release>
                     <debug>true</debug>
                     <showDeprecation>true</showDeprecation>
                     <showWarnings>true</showWarnings>
@@ -105,7 +109,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -118,7 +122,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.5.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -131,7 +135,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.1</version>
+                <version>0.8.10</version>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>
@@ -153,7 +157,7 @@
         <dependency>
             <groupId>com.mercateo</groupId>
             <artifactId>common.rest.schemagen</artifactId>
-            <version>0.20.0</version>
+            <version>0.21.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
@@ -166,27 +170,32 @@
             <version>${spring.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>6.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <version>2.0.1</version>
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.9.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>4.6.1</version>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>5.4.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.23.1</version>
+            <version>3.24.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -198,7 +207,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.11</version>
+            <version>1.4.8</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -216,7 +225,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
+                        <version>3.1.0</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>

--- a/pom.xml
+++ b/pom.xml
@@ -2,9 +2,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.mercateo.oss.parent</groupId>
+        <groupId>com.mercateo.oss</groupId>
         <artifactId>oss-parent-pom</artifactId>
-        <version>0.9.0</version>
+        <version>1.0.9</version>
     </parent>
 
     <groupId>com.mercateo.rest</groupId>
@@ -35,19 +35,6 @@
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
-    <developers>
-        <developer>
-            <id>andreas_wuerl</id>
-            <name>Andreas Würl</name>
-            <email>andreas.wuerl@mercateo.com</email>
-            <url>http://www.mercateo.com</url>
-            <organization>Mercateo AG</organization>
-            <organizationUrl>http://www.mercateo.com</organizationUrl>
-            <roles>
-                <role>developer</role>
-            </roles>
-        </developer>
-    </developers>
     <licenses>
         <license>
             <name>ASL2</name>

--- a/src/main/java/com/mercateo/rest/schemagen/spring/HttpRequestMapper.java
+++ b/src/main/java/com/mercateo/rest/schemagen/spring/HttpRequestMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © 2017 Mercateo AG (http://www.mercateo.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/mercateo/rest/schemagen/spring/HttpRequestMapper.java
+++ b/src/main/java/com/mercateo/rest/schemagen/spring/HttpRequestMapper.java
@@ -17,14 +17,13 @@ package com.mercateo.rest.schemagen.spring;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 class HttpRequestMapper {
     Map<String, List<String>> requestHeaders(HttpServletRequest httpServletRequest) {

--- a/src/main/java/com/mercateo/rest/schemagen/spring/JerseyHateoasConfiguration.java
+++ b/src/main/java/com/mercateo/rest/schemagen/spring/JerseyHateoasConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © 2017 Mercateo AG (http://www.mercateo.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,16 @@
  * limitations under the License.
  */
 package com.mercateo.rest.schemagen.spring;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 import com.mercateo.common.rest.schemagen.JsonHyperSchemaCreator;
 import com.mercateo.common.rest.schemagen.JsonSchemaGenerator;
@@ -32,17 +42,7 @@ import com.mercateo.common.rest.schemagen.types.ListResponseBuilderCreator;
 import com.mercateo.common.rest.schemagen.types.ObjectWithSchemaCreator;
 import com.mercateo.common.rest.schemagen.types.PaginatedResponseBuilderCreator;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-
 import jakarta.servlet.http.HttpServletRequest;
-
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
-import org.springframework.context.annotation.ScopedProxyMode;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 
 @Configuration
 public class JerseyHateoasConfiguration {

--- a/src/main/java/com/mercateo/rest/schemagen/spring/JerseyHateoasConfiguration.java
+++ b/src/main/java/com/mercateo/rest/schemagen/spring/JerseyHateoasConfiguration.java
@@ -35,7 +35,7 @@ import com.mercateo.common.rest.schemagen.types.PaginatedResponseBuilderCreator;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/test/java/com/mercateo/rest/schemagen/spring/JerseyHateoasConfigurationTest.java
+++ b/src/test/java/com/mercateo/rest/schemagen/spring/JerseyHateoasConfigurationTest.java
@@ -1,9 +1,23 @@
+/*
+ * Copyright © 2017 Mercateo AG (http://www.mercateo.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.mercateo.rest.schemagen.spring;
 
-import com.mercateo.common.rest.schemagen.link.LinkFactoryContext;
-import com.mercateo.common.rest.schemagen.plugin.FieldCheckerForSchema;
-import com.mercateo.common.rest.schemagen.plugin.MethodCheckerForLink;
-import com.mercateo.common.rest.schemagen.plugin.TargetSchemaEnablerForLink;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,8 +27,10 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
+import com.mercateo.common.rest.schemagen.link.LinkFactoryContext;
+import com.mercateo.common.rest.schemagen.plugin.FieldCheckerForSchema;
+import com.mercateo.common.rest.schemagen.plugin.MethodCheckerForLink;
+import com.mercateo.common.rest.schemagen.plugin.TargetSchemaEnablerForLink;
 
 @ExtendWith(SpringExtension.class)
 @WebAppConfiguration

--- a/src/test/java/com/mercateo/rest/schemagen/spring/JerseyHateoasConfigurationTest.java
+++ b/src/test/java/com/mercateo/rest/schemagen/spring/JerseyHateoasConfigurationTest.java
@@ -1,23 +1,22 @@
 package com.mercateo.rest.schemagen.spring;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-
 import com.mercateo.common.rest.schemagen.link.LinkFactoryContext;
 import com.mercateo.common.rest.schemagen.plugin.FieldCheckerForSchema;
 import com.mercateo.common.rest.schemagen.plugin.MethodCheckerForLink;
 import com.mercateo.common.rest.schemagen.plugin.TargetSchemaEnablerForLink;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 
-@RunWith(SpringRunner.class)
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(SpringExtension.class)
 @WebAppConfiguration
 public class JerseyHateoasConfigurationTest {
 


### PR DESCRIPTION
Property changes
  - java.version: 1.8 > 17 (also in the maven-compiler-plugin)
  - spring.version: 5.0.20.RELEASE > 6.0.10 Dependency updates
  - Added:
    - maven-surefire-plugin: 3.1.2
    - jakarta.servlet-api: 6.0.0 - jakarta.inject-api: 2.0.1 - junit-jupiter-engine: 5.9.1 - mockito-junit-jupiter: 5.4.0
  - Removed: - javax.servlet-api: 3.1.0 - junit: 4.13.2 - mockito-core: 4.6.1
  - Updated:
    - maven-release-plugin: 3.0.1 > 3.1.2
    - nexus-staging-maven-plugin: 1.6.8 > 1.6.13 - maven-compiler-plugin: 3.7.0 > 3.11.0 - maven-source-plugin: 3.0.1 > 3.3.0 - maven-javadoc-plugin: 3.0.1 > 3.5.0 - jacoco-maven-plugin: 0.8.1 > 0.8.10 - (org.mercateo.)common.rest.schemagen: 0.20.0 > 0.21.0-SNAPSHOT - assertj-core: 3.23.1 > 3.24.2 - logback-classic: 1.2.11 > 1.4.8 - maven-gpg-plugin: 1.6 > 3.1.0